### PR TITLE
Step up authentication pysaml 7.1 fix

### DIFF
--- a/src/satosa/micro_services/stepup.py
+++ b/src/satosa/micro_services/stepup.py
@@ -16,7 +16,6 @@ from urllib.parse import urlparse
 
 from saml2 import BINDING_HTTP_POST
 import saml2.xmldsig as ds
-from saml2.authn_context import requested_authn_context
 from saml2.client import Saml2Client
 from saml2.config import SPConfig
 from saml2.metadata import create_metadata_string
@@ -228,7 +227,8 @@ class StepUp(ResponseMicroService):
         self, context, internal_response, authn_context, nameid_value
     ):
         entityid = self.sp.metadata.identity_providers()[0]
-        req_authn_context = dict(authn_context_class_ref=[authn_context], comparison="exact")
+        req_authn_context = dict(authn_context_class_ref=[authn_context],
+                                 comparison="exact")
         relay_state = util.rndstr()
         sign = self.sp.config.getattr("authn_requests_signed") or bool(
             self.sp.config.key_file and self.sp.config.cert_file

--- a/src/satosa/micro_services/stepup.py
+++ b/src/satosa/micro_services/stepup.py
@@ -228,8 +228,7 @@ class StepUp(ResponseMicroService):
         self, context, internal_response, authn_context, nameid_value
     ):
         entityid = self.sp.metadata.identity_providers()[0]
-        req_authn_context = requested_authn_context(authn_context,
-                                                    comparison="exact")
+        req_authn_context = dict(authn_context_class_ref=[authn_context], comparison="exact")
         relay_state = util.rndstr()
         sign = self.sp.config.getattr("authn_requests_signed") or bool(
             self.sp.config.key_file and self.sp.config.cert_file


### PR DESCRIPTION
Fixes incompatibility with pysaml 7.1.0

- Initializes `req_authn_context` as a dictionary rather than assigning it to 'RequestedAuthnContext' object via call to `requested_authn_contex` to avoid 'Uncaught SATOSA error'
- Removes (now) unnecessary import of `saml2.authn_context.requested_authn_context`

When the current version of the stepup microservice is run using the recently releaased pysaml2 7.10, it results in an 'Uncaught SATOSA error'. This is because `create_authn_request` in  `client_base.py` expects that the `requested_authn_context`, is of type `dict`, and the microservice passes in a `RequestedAuthnContext` object.

The documentation contains the dictionary specification for [requested_authn_context](https://pysaml2.readthedocs.io/en/latest/howto/config.html#requested-authn-context)

I haven't reviewed the pysaml code thoroughly enough to understand the why the changes were made to 7.1.0, (and why it worked before), but code added in this version calls `requested_authn_context.get()` which will throw an exception when the variable is an object rather than a dict.

A stack trace illustrating the problem:
```
[2022-01-12 13:44:16,297] [DEBUG] [saml2.mdstore]: service => [{'__class__': 'urn:oasis:names:tc:SAML:2.0:metadata&SingleSignOnService', 'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect', 'location': 'https://login-mfa-stage.nersc.gov/saml/sso/redirect'}]
[2022-01-12 13:44:16,297] [INFO] [saml2.client]: destination to provider: https://login-mfa-stage.nersc.gov/saml/sso/redirect
[2022-01-12 13:44:16,297] [ERROR] [satosa.base]: [urn:uuid:400696d0-1689-400f-8ae1-7f7591df213b] Uncaught SATOSA error
Traceback (most recent call last):
  File "src/stepup.py", line 263, in _send_authn_to_stepup_service
    **kwargs
  File "/usr/local/lib/python3.7/site-packages/saml2/client.py", line 85, in prepare_for_authenticate
    **kwargs,
  File "/usr/local/lib/python3.7/site-packages/saml2/client.py", line 158, in prepare_for_negotiated_authenticate
    **kwargs,
  File "/usr/local/lib/python3.7/site-packages/saml2/client_base.py", line 368, in create_authn_request
    requested_authn_context_accrs = requested_authn_context.get(
AttributeError: 'RequestedAuthnContext' object has no attribute 'get'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/satosa/base.py", line 240, in run
    resp = self._run_bound_endpoint(context, spec)
  File "/usr/local/lib/python3.7/site-packages/satosa/base.py", line 180, in _run_bound_endpoint
    return spec(context)
  File "/usr/local/lib/python3.7/site-packages/satosa/backends/saml2.py", line 350, in authn_response
    return self.auth_callback_func(context, self._translate_response(authn_response, context.state))
  File "/usr/local/lib/python3.7/site-packages/satosa/base.py", line 149, in _auth_resp_callback_func
    context, internal_response)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/primary_identifier.py", line 264, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/ldap_attribute_store.py", line 618, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/add_nersc_eppn.py", line 86, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/add_posix_groups.py", line 365, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/subject_id.py", line 44, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/check_mfa_exemptions.py", line 96, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/stepup.py", line 222, in process
    nameid_value
  File "src/stepup.py", line 273, in _send_authn_to_stepup_service
    raise StepUpError(error_context) from e
stepup.StepUpError: {'message': 'Failed to construct the AuthnRequest', 'entityid': 'https://login-mfa-stage.nersc.gov/stepup/idp', 'name_id': <saml2.saml.NameID object at 0x7f684c0a5410>, 'params': {'sigalg': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', 'digest_alg': 'http://www.w3.org/2001/04/xmlenc#sha256', 'subject': <saml2.saml.Subject object at 0x7f684c0a55d0>, 'requested_authn_context': <saml2.samlp.RequestedAuthnContext object at 0x7f684c51aed0>}, 'sign': True}
[2022-01-12 13:44:16,304] [ERROR] [satosa.proxy_server]: {'message': 'Failed to construct the AuthnRequest', 'entityid': 'https://login-mfa-stage.nersc.gov/stepup/idp', 'name_id': <saml2.saml.NameID object at 0x7f684c0a5410>, 'params': {'sigalg': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', 'digest_alg': 'http://www.w3.org/2001/04/xmlenc#sha256', 'subject': <saml2.saml.Subject object at 0x7f684c0a55d0>, 'requested_authn_context': <saml2.samlp.RequestedAuthnContext object at 0x7f684c51aed0>}, 'sign': True}
Traceback (most recent call last):
  File "src/stepup.py", line 263, in _send_authn_to_stepup_service
    **kwargs
  File "/usr/local/lib/python3.7/site-packages/saml2/client.py", line 85, in prepare_for_authenticate
    **kwargs,
  File "/usr/local/lib/python3.7/site-packages/saml2/client.py", line 158, in prepare_for_negotiated_authenticate
    **kwargs,
  File "/usr/local/lib/python3.7/site-packages/saml2/client_base.py", line 368, in create_authn_request
    requested_authn_context_accrs = requested_authn_context.get(
AttributeError: 'RequestedAuthnContext' object has no attribute 'get'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/satosa/proxy_server.py", line 118, in __call__
    resp = self.run(context)
  File "/usr/local/lib/python3.7/site-packages/satosa/base.py", line 240, in run
    resp = self._run_bound_endpoint(context, spec)
  File "/usr/local/lib/python3.7/site-packages/satosa/base.py", line 180, in _run_bound_endpoint
    return spec(context)
  File "/usr/local/lib/python3.7/site-packages/satosa/backends/saml2.py", line 350, in authn_response
    return self.auth_callback_func(context, self._translate_response(authn_response, context.state))
  File "/usr/local/lib/python3.7/site-packages/satosa/base.py", line 149, in _auth_resp_callback_func
    context, internal_response)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/primary_identifier.py", line 264, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/ldap_attribute_store.py", line 618, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/add_nersc_eppn.py", line 86, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/add_posix_groups.py", line 365, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/subject_id.py", line 44, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/check_mfa_exemptions.py", line 96, in process
    return super().process(context, data)
  File "/usr/local/lib/python3.7/site-packages/satosa/micro_services/base.py", line 33, in process
    return self.next(context, data)
  File "src/stepup.py", line 222, in process
    nameid_value
  File "src/stepup.py", line 273, in _send_authn_to_stepup_service
    raise StepUpError(error_context) from e
stepup.StepUpError: {'message': 'Failed to construct the AuthnRequest', 'entityid': 'https://login-mfa-stage.nersc.gov/stepup/idp', 'name_id': <saml2.saml.NameID object at 0x7f684c0a5410>, 'params': {'sigalg': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', 'digest_alg': 'http://www.w3.org/2001/04/xmlenc#sha256', 'subject': <saml2.saml.Subject object at 0x7f684c0a55d0>, 'requested_authn_context': <saml2.samlp.RequestedAuthnContext object at 0x7f684c51aed0>}, 'sign': True}
```
